### PR TITLE
Potential Solution for weird crashing, general improvements

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -3,14 +3,17 @@
         {
             "name": "Quest",
             "defines": [
-                "MOD_ID=\"BeatTogether\"",
+                "ID=\"BeatTogether\"",
                 "VERSION=\"1.1.0\"",
                 "__GNUC__",
-                "__aarch64__"
+                "__aarch64__",
+                "HOST_NAME=\"btogether.xn--9o8hpe.ws\"",
+                "PORT=2328",
+                "STATUS_URL=\"http://btogether.xn--9o8hpe.ws/status\""
             ],
             "includePath": [
                 "${workspaceFolder}/**",
-                "C:/Program Files/Unity/Hub/Editor/2018.3.14f1/Editor/Data/il2cpp/libil2cpp",
+                "${workspaceFolder}/extern/libil2cpp/il2cpp/libil2cpp",
                 "c:/android-ndk/**"
             ],
             "cStandard": "c11",

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -123,12 +123,18 @@ Il2CppString* getCustomLevelStr() {
     return customStr;
 }
 
+// Helper method for concatenating two strings using the Concat(System.Object) method.
+Il2CppString* concatHelper(Il2CppString* src, Il2CppString* dst) {
+    static auto* concatMethod = il2cpp_utils::FindMethod(il2cpp_functions::defaults->string_class, "Concat", std::vector<Il2CppClass*>{il2cpp_functions::defaults->object_class});
+    return RET_DEFAULT_UNLESS(getLogger(), il2cpp_utils::RunMethod<Il2CppString*>(src, concatMethod, dst));
+}
+
 // Makes the Level ID stored in this identifer lower case if it is a custom level
 void makeIdLowerCase(BeatmapIdentifierNetSerializable* identifier)
 {
     // Check if it is a custom level
     if (identifier->levelID->StartsWith(getCustomLevelStr()))
-        identifier->set_levelID(getCustomLevelStr()->Concat(identifier->levelID->Substring(customLevelPrefixLength)->ToLower()));
+        identifier->set_levelID(RET_V_UNLESS(getLogger(), concatHelper(getCustomLevelStr(), identifier->levelID->Substring(customLevelPrefixLength)->ToLower())));
 }
 
 // Makes the Level ID stored in this identifer upper case if it is a custom level
@@ -136,7 +142,7 @@ void makeIdUpperCase(BeatmapIdentifierNetSerializable* identifier)
 {
     // Check if it is a custom level
     if (identifier->levelID->StartsWith(getCustomLevelStr()))
-        identifier->set_levelID(getCustomLevelStr()->Concat(identifier->levelID->Substring(customLevelPrefixLength)->ToUpper()));
+        identifier->set_levelID(RET_V_UNLESS(getLogger(), concatHelper(getCustomLevelStr(), identifier->levelID->Substring(customLevelPrefixLength)->ToUpper())));
 }
 
 MAKE_HOOK_OFFSETLESS(PlatformAuthenticationTokenProvider_GetAuthenticationToken, System::Threading::Tasks::Task_1<GlobalNamespace::AuthenticationToken>*, PlatformAuthenticationTokenProvider* self)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -141,14 +141,13 @@ void makeIdUpperCase(BeatmapIdentifierNetSerializable* identifier)
 
 MAKE_HOOK_OFFSETLESS(PlatformAuthenticationTokenProvider_GetAuthenticationToken, System::Threading::Tasks::Task_1<GlobalNamespace::AuthenticationToken>*, PlatformAuthenticationTokenProvider* self)
 {
-    auto authenticationToken = AuthenticationToken(
+    getLogger().debug("Returning custom authentication token!");
+    return System::Threading::Tasks::Task_1<AuthenticationToken>::New_ctor(AuthenticationToken(
         AuthenticationToken::Platform::OculusQuest,
         self->userId,
         self->userName,
         Array<uint8_t>::NewLength(0)
-    );
-    getLogger().debug("Returning custom authentication token!");
-    return System::Threading::Tasks::Task_1<AuthenticationToken>::New_ctor(authenticationToken);
+    ));
 }
 
 MAKE_HOOK_OFFSETLESS(MainSystemInit_Init, void, MainSystemInit* self) {


### PR DESCRIPTION
This PR implements the following:

- Configuration improvements (see `TODO` comments for assumptions that I made and assumptions that could be made to simplify it further). I designed this configuration in such a way that you can call `read` on it multiple times, but that is not necessarily desired.
- General readability improvements, including proper usage of defines listed, proper include path to libil2cpp explicitly, and macro ensurance
- Reduced string allocations. Nearly all strings created are done so in un-gc-able ways, with manual strings being used as replacements for nearly all C++ strings
- Magic number removal for the number `13`
- Removal of the unnecessary single element in the `sessionToken` array
- Attempt to ensure that array allocations happen slightly later, in an effort to trick GC into avoiding cleaning them up
- Use a different hook for certificate chain completion because the other hook was too small to hook safely (verified via Ghidra dump, offset is: `0x1c22978`)

General Note:
I performed a few style changes, so feel free to reject the PR on the basis of those, although I cannot guarantee when I can next look at this.
It is always a good idea to ensure you check the locations you are hooking to make sure they are large enough. The original certificate chain hook was actually overwriting a few bytes into an unrelated method and causing damage that was unnoticeable. This should help fix some crash cases.

As always, message me on Discord at `Sc2ad#8836` !