### PR TITLE
Fixed custom-song softlocking.

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -8,18 +8,18 @@ TARGET_ARCH_ABI := arm64-v8a
 include $(CLEAR_VARS)
 LOCAL_MODULE := hook
 rwildcard=$(wildcard $1$2) $(foreach d,$(wildcard $1*),$(call rwildcard,$d/,$2))
-# Creating prebuilt for dependency: codegen - version: 0.6.1
+# Creating prebuilt for dependency: codegen - version: 0.6.2
 include $(CLEAR_VARS)
-LOCAL_MODULE := codegen_0_6_1
+LOCAL_MODULE := codegen_0_6_2
 LOCAL_EXPORT_C_INCLUDES := extern/codegen
-LOCAL_SRC_FILES := extern/libcodegen_0_6_1.so
+LOCAL_SRC_FILES := extern/libcodegen_0_6_2.so
 LOCAL_CPP_FEATURES += exceptions
 include $(PREBUILT_SHARED_LIBRARY)
-# Creating prebuilt for dependency: beatsaber-hook - version: 1.0.10
+# Creating prebuilt for dependency: beatsaber-hook - version: 1.0.12
 include $(CLEAR_VARS)
-LOCAL_MODULE := beatsaber-hook_1_0_10
+LOCAL_MODULE := beatsaber-hook_1_0_12
 LOCAL_EXPORT_C_INCLUDES := extern/beatsaber-hook
-LOCAL_SRC_FILES := extern/libbeatsaber-hook_1_0_10.so
+LOCAL_SRC_FILES := extern/libbeatsaber-hook_1_0_12.so
 include $(PREBUILT_SHARED_LIBRARY)
 # Creating prebuilt for dependency: modloader - version: 1.0.4
 include $(CLEAR_VARS)
@@ -34,8 +34,8 @@ LOCAL_SRC_FILES += $(call rwildcard,src/,*.cpp)
 LOCAL_SRC_FILES += $(call rwildcard,extern/beatsaber-hook/src/inline-hook,*.cpp)
 LOCAL_SRC_FILES += $(call rwildcard,extern/beatsaber-hook/src/inline-hook,*.c)
 LOCAL_SHARED_LIBRARIES += modloader
-LOCAL_SHARED_LIBRARIES += beatsaber-hook_1_0_10
-LOCAL_SHARED_LIBRARIES += codegen_0_6_1
+LOCAL_SHARED_LIBRARIES += beatsaber-hook_1_0_12
+LOCAL_SHARED_LIBRARIES += codegen_0_6_2
 LOCAL_LDLIBS += -llog
 LOCAL_CFLAGS += -I'extern/libil2cpp/il2cpp/libil2cpp' -DID='"BeatTogether"' -DVERSION='"$(VERSION)"' -DHOST_NAME='"$(HOST_NAME)"' -DPORT='$(PORT)' -DSTATUS_URL='$(STATUS_URL)' -I'./shared' -I'./extern' -isystem'./extern/codegen/include'
 LOCAL_CPPFLAGS += -std=c++2a

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -258,7 +258,6 @@ MAKE_HOOK_OFFSETLESS(MainMenuViewController_DidActivate, void, MainMenuViewContr
 MAKE_HOOK_OFFSETLESS(AdditionalContentModel_GetLevelEntitlementStatusAsync, System::Threading::Tasks::Task_1<AdditionalContentModel::EntitlementStatus>*, AdditionalContentModel* self, Il2CppString* levelId, System::Threading::CancellationToken token) {
     static BeatmapLevelsModel* levelsModel = UnityEngine::Resources::FindObjectsOfTypeAll<BeatmapLevelsModel*>()->values[0];
     if(!levelsModel->IsBeatmapLevelLoaded(levelId)) {
-        getLogger().info("custom song not owned!");
         return System::Threading::Tasks::Task_1<AdditionalContentModel::EntitlementStatus>::New_ctor(AdditionalContentModel::EntitlementStatus::NotOwned);
     }
     

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -252,7 +252,7 @@ MAKE_HOOK_OFFSETLESS(MainMenuViewController_DidActivate, void, MainMenuViewContr
     MainMenuViewController_DidActivate(self, firstActivation, addedToHierarchy, systemScreenEnabling);
 }
 
-// The base game's code always returns pwmed for a custom song, regardless of if we actually have it downloaded.
+// The base game's code always returns owned for a custom song, regardless of if we actually have it downloaded.
 // We change this to only return owned if we actually have a level with that ID loaded.
 // This fixes issues with people soft-locking if they don't have the song - players will be told if someone doesn't have it downloaded.
 MAKE_HOOK_OFFSETLESS(AdditionalContentModel_GetLevelEntitlementStatusAsync, System::Threading::Tasks::Task_1<AdditionalContentModel::EntitlementStatus>*, AdditionalContentModel* self, Il2CppString* levelId, System::Threading::CancellationToken token) {


### PR DESCRIPTION
This pull request:
- Fixes the issue where the game reports that a player is able to play a custom song that they don't have. (fixing the entitlement check - this means that players will be told if others don't have the song, makes for a better user experience).
- Fixed issue where the play button still appears as clickable, even with the above fixed. This stops players from starting the song and crashing others' games.